### PR TITLE
[SCI-15310] [NGX][NGL] Use camera type string instead of ID for Camera APIs

### DIFF
--- a/miniweb-core/src/main/java/com/devsmart/miniweb/handlers/controller/ParamHandlerFactory.java
+++ b/miniweb-core/src/main/java/com/devsmart/miniweb/handlers/controller/ParamHandlerFactory.java
@@ -19,11 +19,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.net.ProtocolException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 
 public class ParamHandlerFactory {
 
@@ -142,7 +145,13 @@ public class ParamHandlerFactory {
             public Object createParam(HttpRequest request, HttpResponse response, HttpContext context, ControllerInvoker controllerInvoker) {
 
                 final String uri = request.getRequestLine().getUri();
-                Map<String, List<String>> params = UriQueryParser.getUrlParameters(uri);
+                Map<String, List<String>> params;
+                try {
+                    params = UriQueryParser.getUrlParameters(uri);
+                } catch (ProtocolException e) {
+                    response.setStatusCode(SC_BAD_REQUEST);
+                    return null;
+                }
 
                 List<String> values = params.get(paramKey.value());
                 if (values != null) {

--- a/miniweb-core/src/main/java/com/devsmart/miniweb/utils/UriQueryParser.java
+++ b/miniweb-core/src/main/java/com/devsmart/miniweb/utils/UriQueryParser.java
@@ -2,6 +2,7 @@ package com.devsmart.miniweb.utils;
 
 
 import java.io.UnsupportedEncodingException;
+import java.net.ProtocolException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class UriQueryParser {
 
     }
 
-    public static Map<String, List<String>> getUrlParameters(String url) {
+    public static Map<String, List<String>> getUrlParameters(String url) throws ProtocolException {
         try {
 
             final Map<String, List<String>> query_pairs = new LinkedHashMap<String, List<String>>();
@@ -62,6 +63,8 @@ public class UriQueryParser {
 
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
+        } catch (IllegalArgumentException e) {
+            throw new ProtocolException(e.getMessage());
         }
     }
 }

--- a/miniweb-core/src/test/java/com/devsmart/miniweb/utils/UriQueryParserTest.java
+++ b/miniweb-core/src/test/java/com/devsmart/miniweb/utils/UriQueryParserTest.java
@@ -3,6 +3,7 @@ package com.devsmart.miniweb.utils;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.net.ProtocolException;
 import java.util.List;
 import java.util.Map;
 
@@ -13,10 +14,17 @@ public class UriQueryParserTest {
     public void test() {
 
         String uri = "/stuff/test?param1=itworked&param2=rad&param1=cool";
+        boolean exceptionHappened = false;
 
-        Map<String, List<String>> params = UriQueryParser.getUrlParameters(uri);
+        Map<String, List<String>> params = null;
+        try {
+            params = UriQueryParser.getUrlParameters(uri);
+        } catch (ProtocolException e) {
+            exceptionHappened = true;
+        }
 
         assertNotNull(params);
+        assertNotEquals(exceptionHappened, true);
         assertEquals(2, params.get("param1").size());
         assertEquals("itworked", params.get("param1").get(0));
         assertEquals("cool", params.get("param1").get(1));
@@ -24,5 +32,12 @@ public class UriQueryParserTest {
         assertEquals(1, params.get("param2").size());
         assertEquals("rad", params.get("param2").get(0));
 
+        uri = "/stuff/test?param1=itworked&param2=rad&param1=%cool";
+        try {
+            params = UriQueryParser.getUrlParameters(uri);
+        } catch (ProtocolException e) {
+            exceptionHappened = true;
+        }
+        assertTrue(exceptionHappened);
     }
 }


### PR DESCRIPTION
Changes:
 - handle a case when url parameters contain extra symbols